### PR TITLE
useModelStream register streaming openai

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { EventType, logger, ModelType, VECTOR_DIMS } from '@elizaos/core';
 import {
   generateObject,
   generateText,
+  streamText,
   JSONParseError,
   type JSONValue,
   type LanguageModelUsage,
@@ -362,6 +363,171 @@ export const openaiPlugin: Plugin = {
     OPENAI_EXPERIMENTAL_TELEMETRY: process.env.OPENAI_EXPERIMENTAL_TELEMETRY,
   },
   async init(_config, runtime) {
+    // Register streaming text models (TEXT_SMALL, TEXT_LARGE)
+    try {
+      runtime.registerModelStream(
+        ModelType.TEXT_SMALL,
+        async function* (params: GenerateTextParams) {
+          const openai = createOpenAIClient(runtime);
+          const modelName = getSmallModel(runtime);
+          const experimentalTelemetry = getExperimentalTelemetry(runtime);
+          const system = runtime.character.system ?? undefined;
+
+          const {
+            prompt,
+            stopSequences = [],
+            maxTokens = 8192,
+            temperature = 0.7,
+            frequencyPenalty = 0.7,
+            presencePenalty = 0.7,
+          } = params;
+
+          logger.log(`[OpenAI] [stream] Using TEXT_SMALL model: ${modelName}`);
+          let fullText = '';
+          try {
+            const { textStream, usage } = await streamText({
+              model: openai.languageModel(modelName),
+              prompt,
+              system,
+              temperature,
+              maxTokens,
+              frequencyPenalty,
+              presencePenalty,
+              stopSequences,
+              experimental_telemetry: { isEnabled: experimentalTelemetry },
+            });
+
+            for await (const delta of textStream) {
+              const s = String(delta ?? '');
+              if (s.length > 0) {
+                fullText += s;
+                yield { event: 'delta', delta: s } as any;
+              }
+            }
+
+            if (usage) {
+              yield {
+                event: 'usage',
+                tokens: {
+                  prompt: usage.promptTokens,
+                  completion: usage.completionTokens,
+                  total: usage.totalTokens,
+                },
+              } as any;
+            }
+
+            yield { event: 'finish', output: fullText } as any;
+          } catch (error) {
+            yield { event: 'error', error } as any;
+          }
+        },
+        'openai',
+        100
+      );
+    } catch (err) {
+      logger.warn(`[OpenAI] Failed to register TEXT_SMALL streaming: ${String(err)}`);
+    }
+
+    try {
+      runtime.registerModelStream(
+        ModelType.TEXT_LARGE,
+        async function* (params: GenerateTextParams) {
+          const openai = createOpenAIClient(runtime);
+          const modelName = getLargeModel(runtime);
+          const experimentalTelemetry = getExperimentalTelemetry(runtime);
+          const system = runtime.character.system ?? undefined;
+
+          const {
+            prompt,
+            stopSequences = [],
+            maxTokens = 8192,
+            temperature = 0.7,
+            frequencyPenalty = 0.7,
+            presencePenalty = 0.7,
+          } = params;
+
+          logger.log(`[OpenAI] [stream] Using TEXT_LARGE model: ${modelName}`);
+          let fullText = '';
+          try {
+            const { textStream, usage } = await streamText({
+              model: openai.languageModel(modelName),
+              prompt,
+              system,
+              temperature,
+              maxTokens,
+              frequencyPenalty,
+              presencePenalty,
+              stopSequences,
+              experimental_telemetry: { isEnabled: experimentalTelemetry },
+            });
+
+            for await (const delta of textStream) {
+              const s = String(delta ?? '');
+              if (s.length > 0) {
+                fullText += s;
+                yield { event: 'delta', delta: s } as any;
+              }
+            }
+
+            if (usage) {
+              yield {
+                event: 'usage',
+                tokens: {
+                  prompt: usage.promptTokens,
+                  completion: usage.completionTokens,
+                  total: usage.totalTokens,
+                },
+              } as any;
+            }
+
+            yield { event: 'finish', output: fullText } as any;
+          } catch (error) {
+            yield { event: 'error', error } as any;
+          }
+        },
+        'openai',
+        100
+      );
+    } catch (err) {
+      logger.warn(`[OpenAI] Failed to register TEXT_LARGE streaming: ${String(err)}`);
+    }
+
+    // Streaming TTS: stream audio chunks if server supports streaming response
+    try {
+      runtime.registerModelStream(
+        ModelType.TEXT_TO_SPEECH,
+        async function* (text: string) {
+          try {
+            const resBody = await fetchTextToSpeech(runtime, text);
+            if (!resBody || typeof (resBody as any).getReader !== 'function') {
+              // Not a stream; emit a single finish chunk
+              yield { event: 'finish', output: resBody } as any;
+              return;
+            }
+            const reader = (resBody as any).getReader();
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) {
+                  yield { event: 'audio', chunk: value } as any;
+                }
+              }
+            } finally {
+              reader.releaseLock?.();
+            }
+            yield { event: 'finish', output: null } as any;
+          } catch (error) {
+            yield { event: 'error', error } as any;
+          }
+        },
+        'openai',
+        90
+      );
+    } catch (err) {
+      logger.warn(`[OpenAI] Failed to register TEXT_TO_SPEECH streaming: ${String(err)}`);
+    }
+
     // do check in the background
     new Promise<void>(async (resolve) => {
       resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,12 +406,13 @@ export const openaiPlugin: Plugin = {
             }
 
             if (usage) {
+              const resolvedUsage = await usage;
               yield {
                 event: 'usage',
                 tokens: {
-                  prompt: usage.promptTokens,
-                  completion: usage.completionTokens,
-                  total: usage.totalTokens,
+                  prompt: resolvedUsage.promptTokens,
+                  completion: resolvedUsage.completionTokens,
+                  total: resolvedUsage.totalTokens,
                 },
               } as any;
             }
@@ -470,12 +471,13 @@ export const openaiPlugin: Plugin = {
             }
 
             if (usage) {
+              const resolvedUsage = await usage;
               yield {
                 event: 'usage',
                 tokens: {
-                  prompt: usage.promptTokens,
-                  completion: usage.completionTokens,
-                  total: usage.totalTokens,
+                  prompt: resolvedUsage.promptTokens,
+                  completion: resolvedUsage.completionTokens,
+                  total: resolvedUsage.totalTokens,
                 },
               } as any;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ import type {
   Plugin,
   TextEmbeddingParams,
   TokenizeTextParams,
+  type TextStreamChunk,
+  type TextToSpeechStreamChunk,
 } from '@elizaos/core';
+
 import { EventType, logger, ModelType, VECTOR_DIMS } from '@elizaos/core';
 import {
   generateObject,
@@ -43,7 +46,7 @@ function getSetting(
  * @returns The resolved base URL for OpenAI API requests.
  */
 function getBaseURL(runtime: IAgentRuntime): string {
-  const baseURL = getSetting(runtime, 'OPENAI_BASE_URL', 'https://api.openai.com/v1') as string;
+  const baseURL = String(getSetting(runtime, 'OPENAI_BASE_URL', 'https://api.openai.com/v1'));
   logger.debug(`[OpenAI] Default base URL: ${baseURL}`);
   return baseURL;
 }
@@ -98,7 +101,7 @@ function getEmbeddingApiKey(runtime: IAgentRuntime): string | undefined {
 function getSmallModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, 'OPENAI_SMALL_MODEL') ??
-    (getSetting(runtime, 'SMALL_MODEL', 'gpt-4o-mini') as string)
+    String(getSetting(runtime, 'SMALL_MODEL', 'gpt-4o-mini'))
   );
 }
 
@@ -111,7 +114,7 @@ function getSmallModel(runtime: IAgentRuntime): string {
 function getLargeModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, 'OPENAI_LARGE_MODEL') ??
-    (getSetting(runtime, 'LARGE_MODEL', 'gpt-4o') as string)
+    String(getSetting(runtime, 'LARGE_MODEL', 'gpt-4o'))
   );
 }
 
@@ -194,7 +197,7 @@ async function detokenizeText(model: ModelTypeName, tokens: number[]) {
 async function generateObjectByModelType(
   runtime: IAgentRuntime,
   params: ObjectGenerationParams,
-  modelType: string,
+  modelType: ModelTypeName,
   getModelFn: (runtime: IAgentRuntime) => string
 ): Promise<JSONValue> {
   const openai = createOpenAIClient(runtime);
@@ -219,7 +222,7 @@ async function generateObjectByModelType(
     });
 
     if (usage) {
-      emitModelUsageEvent(runtime, modelType as ModelTypeName, params.prompt, usage);
+      emitModelUsageEvent(runtime, modelType, params.prompt, usage);
     }
     return object;
   } catch (error: unknown) {
@@ -365,9 +368,20 @@ export const openaiPlugin: Plugin = {
   async init(_config, runtime) {
     // Register streaming text models (TEXT_SMALL, TEXT_LARGE)
     try {
-      runtime.registerModelStream(
+      const runtimeWithStreaming = runtime as IAgentRuntime & {
+        registerModelStream?: <T>(
+          modelType: ModelTypeName,
+          handler: (params: T) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>,
+          provider: string,
+          priority?: number
+        ) => void
+      };
+      if (!runtimeWithStreaming.registerModelStream) {
+        logger.warn('[OpenAI] Streaming API not supported by this runtime version; skipping TEXT_SMALL stream registration');
+      } else {
+        runtimeWithStreaming.registerModelStream(
         ModelType.TEXT_SMALL,
-        async function* (params: GenerateTextParams) {
+        async function* (params: GenerateTextParams): AsyncGenerator<TextStreamChunk> {
           const openai = createOpenAIClient(runtime);
           const modelName = getSmallModel(runtime);
           const experimentalTelemetry = getExperimentalTelemetry(runtime);
@@ -401,7 +415,7 @@ export const openaiPlugin: Plugin = {
               const s = String(delta ?? '');
               if (s.length > 0) {
                 fullText += s;
-                yield { event: 'delta', delta: s } as any;
+                yield { event: 'delta', delta: s };
               }
             }
 
@@ -414,25 +428,37 @@ export const openaiPlugin: Plugin = {
                   completion: resolvedUsage.completionTokens,
                   total: resolvedUsage.totalTokens,
                 },
-              } as any;
+              };
             }
 
-            yield { event: 'finish', output: fullText } as any;
+            yield { event: 'finish', output: fullText };
           } catch (error) {
-            yield { event: 'error', error } as any;
+            yield { event: 'error', error };
           }
         },
-        'openai',
-        100
-      );
+          'openai',
+          100
+        );
+      }
     } catch (err) {
       logger.warn(`[OpenAI] Failed to register TEXT_SMALL streaming: ${String(err)}`);
     }
 
     try {
-      runtime.registerModelStream(
+      const runtimeWithStreaming = runtime as IAgentRuntime & {
+        registerModelStream?: <T>(
+          modelType: ModelTypeName,
+          handler: (params: T) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>,
+          provider: string,
+          priority?: number
+        ) => void
+      };
+      if (!runtimeWithStreaming.registerModelStream) {
+        logger.warn('[OpenAI] Streaming API not supported by this runtime version; skipping TEXT_LARGE stream registration');
+      } else {
+        runtimeWithStreaming.registerModelStream(
         ModelType.TEXT_LARGE,
-        async function* (params: GenerateTextParams) {
+        async function* (params: GenerateTextParams): AsyncGenerator<TextStreamChunk> {
           const openai = createOpenAIClient(runtime);
           const modelName = getLargeModel(runtime);
           const experimentalTelemetry = getExperimentalTelemetry(runtime);
@@ -466,7 +492,7 @@ export const openaiPlugin: Plugin = {
               const s = String(delta ?? '');
               if (s.length > 0) {
                 fullText += s;
-                yield { event: 'delta', delta: s } as any;
+                yield { event: 'delta', delta: s };
               }
             }
 
@@ -479,53 +505,67 @@ export const openaiPlugin: Plugin = {
                   completion: resolvedUsage.completionTokens,
                   total: resolvedUsage.totalTokens,
                 },
-              } as any;
+              };
             }
 
-            yield { event: 'finish', output: fullText } as any;
+            yield { event: 'finish', output: fullText };
           } catch (error) {
-            yield { event: 'error', error } as any;
+            yield { event: 'error', error };
           }
         },
-        'openai',
-        100
-      );
+          'openai',
+          100
+        );
+      }
     } catch (err) {
       logger.warn(`[OpenAI] Failed to register TEXT_LARGE streaming: ${String(err)}`);
     }
 
     // Streaming TTS: stream audio chunks if server supports streaming response
     try {
-      runtime.registerModelStream(
+      const runtimeWithStreaming = runtime as IAgentRuntime & {
+        registerModelStream?: <T>(
+          modelType: ModelTypeName,
+          handler: (params: T) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>,
+          provider: string,
+          priority?: number
+        ) => void
+      };
+      if (!runtimeWithStreaming.registerModelStream) {
+        logger.warn('[OpenAI] Streaming API not supported by this runtime version; skipping TEXT_TO_SPEECH stream registration');
+      } else {
+        runtimeWithStreaming.registerModelStream(
         ModelType.TEXT_TO_SPEECH,
-        async function* (text: string) {
+        async function* (params: { text: string } | string): AsyncGenerator<TextToSpeechStreamChunk> {
+            const text = typeof params === 'string' ? params : params.text;
           try {
             const resBody = await fetchTextToSpeech(runtime, text);
-            if (!resBody || typeof (resBody as any).getReader !== 'function') {
+            if (!resBody || !('getReader' in resBody) || typeof resBody.getReader !== 'function') {
               // Not a stream; emit a single finish chunk
-              yield { event: 'finish', output: resBody } as any;
+              yield { event: 'finish', output: resBody as unknown as Buffer };
               return;
             }
-            const reader = (resBody as any).getReader();
+            const reader = (resBody as ReadableStream<Uint8Array>).getReader();
             try {
               while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
                 if (value) {
-                  yield { event: 'audio', chunk: value } as any;
+                  yield { event: 'audio', chunk: value };
                 }
               }
             } finally {
               reader.releaseLock?.();
             }
-            yield { event: 'finish', output: null } as any;
+            yield { event: 'finish', output: null };
           } catch (error) {
-            yield { event: 'error', error } as any;
+            yield { event: 'error', error };
           }
         },
-        'openai',
-        90
-      );
+          'openai',
+          90
+        );
+      }
     } catch (err) {
       logger.warn(`[OpenAI] Failed to register TEXT_TO_SPEECH streaming: ${String(err)}`);
     }
@@ -860,7 +900,7 @@ export const openaiPlugin: Plugin = {
       }
 
       try {
-        const requestBody: Record<string, any> = {
+        const requestBody = {
           model: modelName,
           messages: messages,
           max_tokens: maxTokens,


### PR DESCRIPTION
This pull request adds streaming support for text generation and text-to-speech models in the OpenAI plugin, making it possible to receive incremental outputs for both text and audio. The main changes are the registration of streaming handlers for small and large text models, as well as for text-to-speech, which will improve responsiveness and user experience for applications using these models.

**Streaming model registration:**

* Added streaming handlers for `ModelType.TEXT_SMALL` and `ModelType.TEXT_LARGE` that yield incremental text deltas, usage statistics, and final output, using the new `streamText` function. This allows clients to receive partial completions as they are generated.
* Registered a streaming handler for `ModelType.TEXT_TO_SPEECH` that yields audio chunks if the server supports streaming responses, or a single output if not. This enables real-time speech synthesis streaming.

**Core API update:**

* Imported the new `streamText` function from `@elizaos/core` to support streaming text generation.

Ties into /core change PR: https://github.com/elizaOS/eliza/pull/5777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming responses for text generation (small & large models) with token-by-token updates and streaming text-to-speech for progressive audio playback.
* **Performance**
  * Reduced perceived latency via real-time output updates during generation and synthesis.
* **Reliability**
  * Improved streaming error handling with graceful completion and warnings when streaming is unsupported.
* **Chores**
  * Public plugin API unchanged; existing integrations remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->