### PR TITLE
Adjusting default models to save $

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "type": "string",
         "description": "Fallback identifier for the small language model if OPENAI_SMALL_MODEL is not set.",
         "required": false,
-        "default": "gpt-4o-mini",
+        "default": "gpt-5-nano",
         "sensitive": false
       },
       "OPENAI_LARGE_MODEL": {
@@ -80,7 +80,7 @@
         "type": "string",
         "description": "Fallback identifier for the large language model if OPENAI_LARGE_MODEL is not set.",
         "required": false,
-        "default": "gpt-4o",
+        "default": "gpt-5-mini",
         "sensitive": false
       },
       "OPENAI_EMBEDDING_MODEL": {
@@ -113,7 +113,7 @@
         "type": "string",
         "description": "Identifier of the model used for describing images.",
         "required": false,
-        "default": "gpt-4o-mini",
+        "default": "gpt-5-nano",
         "sensitive": false
       },
       "OPENAI_IMAGE_DESCRIPTION_MAX_TOKENS": {


### PR DESCRIPTION
The default models previously set in here can quickly eat up a lot of OpenAI budget. To help new users avoid blowing their entire OpenAI credit allotment, let's start with more economical models by default. The new 5-mini and 5-nano, instead of 4o and 4o-mini, respectively -- will save a new user roughly 90% of their $, before they figure out how to change these defaults to spend more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default AI models to the GPT-5 family for text (small/large) and image description.
  * Users can expect improved response quality, speed, and more accurate image captions out of the box.
  * No action required; custom model overrides continue to be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->